### PR TITLE
Fix a bug to remove `hidden` value KVO observers on arranged subviews

### DIFF
--- a/Example/TZStackView-Example/TZStackView/TZStackView.swift
+++ b/Example/TZStackView-Example/TZStackView/TZStackView.swift
@@ -127,7 +127,7 @@ public class TZStackView: UIView {
         addHiddenListener(arrangedSubview)
     }
 
-    public func hiddenAnimationStopped() {
+    func hiddenAnimationStopped() {
         var queueEntriesToRemove = [TZAnimationDidStopQueueEntry]()
         for entry in animationDidStopQueueEntries {
             let view = entry.view
@@ -143,19 +143,19 @@ public class TZStackView: UIView {
         }
     }
     
-    func addArrangedSubview(view: UIView) {
+    public func addArrangedSubview(view: UIView) {
         view.setTranslatesAutoresizingMaskIntoConstraints(false)
         addSubview(view)
         arrangedSubviews.append(view)
     }
     
-    func removeArrangedSubview(view: UIView) {
+    public func removeArrangedSubview(view: UIView) {
         if let index = find(arrangedSubviews, view) {
             arrangedSubviews.removeAtIndex(index)
         }
     }
 
-    func insertArrangedSubview(view: UIView, atIndex stackIndex: Int) {
+    public func insertArrangedSubview(view: UIView, atIndex stackIndex: Int) {
         arrangedSubviews.insert(view, atIndex: stackIndex)
     }
 

--- a/Example/TZStackView-Example/TZStackView/TZStackView.swift
+++ b/Example/TZStackView-Example/TZStackView/TZStackView.swift
@@ -11,10 +11,6 @@ import UIKit
 struct TZAnimationDidStopQueueEntry: Equatable {
     let view: UIView
     let hidden: Bool
-    init(view: UIView, hidden: Bool) {
-        self.view = view
-        self.hidden = hidden
-    }
 }
 
 func ==(lhs: TZAnimationDidStopQueueEntry, rhs: TZAnimationDidStopQueueEntry) -> Bool {
@@ -41,19 +37,15 @@ public class TZStackView: UIView {
 
     public var spacing: CGFloat = 0
     
-    public var arrangedSubviews: [UIView] {
-        return _arrangedSubviews
-    }
-    
     var layoutMarginsRelativeArrangement = false
 
     private var stackViewConstraints = [NSLayoutConstraint]()
     private var subviewConstraints = [NSLayoutConstraint]()
 
-    private var _arrangedSubviews: [UIView] {
+    private(set) var arrangedSubviews: [UIView] = [] {
         didSet {
             setNeedsUpdateConstraints()
-            registerHiddenListeners()
+            registerHiddenListeners(oldValue)
         }
     }
     
@@ -66,21 +58,23 @@ public class TZStackView: UIView {
     private var animatingToHiddenViews = [UIView]()
 
     public init(arrangedSubviews: [UIView] = []) {
-        self._arrangedSubviews = arrangedSubviews
         super.init(frame: CGRectZero)
-
         for arrangedSubview in arrangedSubviews {
             arrangedSubview.setTranslatesAutoresizingMaskIntoConstraints(false)
             addSubview(arrangedSubview)
         }
-        registerHiddenListeners()
-        registerHiddenListeners()
+
+        // Closure to invoke didSet()
+        { self.arrangedSubviews = arrangedSubviews }()
     }
     
-    private func registerHiddenListeners() {
-        for arrangedSubview in arrangedSubviews {
-            removeHiddenListener(arrangedSubview)
-            addHiddenListener(arrangedSubview)
+    private func registerHiddenListeners(previousArrangedSubviews: [UIView]) {
+        previousArrangedSubviews.map {[weak self] in
+            self?.removeHiddenListener($0)
+        }
+
+        arrangedSubviews.map {[weak self] in
+            self?.addHiddenListener($0)
         }
     }
     
@@ -149,18 +143,20 @@ public class TZStackView: UIView {
         }
     }
     
-    public func addArrangedSubview(view: UIView) {
-        _arrangedSubviews.append(view)
+    func addArrangedSubview(view: UIView) {
+        view.setTranslatesAutoresizingMaskIntoConstraints(false)
+        addSubview(view)
+        arrangedSubviews.append(view)
     }
     
-    public func removeArrangedSubview(view: UIView) {
-        if let index = find(_arrangedSubviews, view) {
-            _arrangedSubviews.removeAtIndex(index)
+    func removeArrangedSubview(view: UIView) {
+        if let index = find(arrangedSubviews, view) {
+            arrangedSubviews.removeAtIndex(index)
         }
     }
 
-    public func insertArrangedSubview(view: UIView, atIndex stackIndex: Int) {
-        _arrangedSubviews.insert(view, atIndex: stackIndex)
+    func insertArrangedSubview(view: UIView, atIndex stackIndex: Int) {
+        arrangedSubviews.insert(view, atIndex: stackIndex)
     }
 
     override public func updateConstraints() {

--- a/Example/TZStackView-Example/TZStackView/TZStackView.swift
+++ b/Example/TZStackView-Example/TZStackView/TZStackView.swift
@@ -68,6 +68,11 @@ public class TZStackView: UIView {
         { self.arrangedSubviews = arrangedSubviews }()
     }
     
+    deinit {
+        // This removes `hidden` value KVO observers using didSet()
+        arrangedSubviews = []
+    }
+    
     private func registerHiddenListeners(previousArrangedSubviews: [UIView]) {
         previousArrangedSubviews.map {[weak self] in
             self?.removeHiddenListener($0)


### PR DESCRIPTION
Fix a bug to remove `hidden` value KVO observers on arranged subviews. Made some code more swift-ish.

This fixes the following (pretty common when using it inside custom `UITableViewCell`):

`2015-06-30 00:41:32.932 DemoApp[2541:396707] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'An instance 0x12ce50d30 of class DemoApp.TZStackView was deallocated while key value observers were still registered with it. Current observation info: <NSKeyValueObservationInfo 0x1706454c0> (
<NSKeyValueObservance 0x1704c1490: Observer: 0x12cd8f440, Key path: hidden, Options: <New: YES, Old: YES, Prior: NO> Context: 0x12cd8f550, Property: 0x174257010>
)'`
`*** First throw call stack:`
