### PR TITLE
Expose enums to objective-c

### DIFF
--- a/Example/TZStackView-Example/TZStackView/TZStackViewAlignment.swift
+++ b/Example/TZStackView-Example/TZStackView/TZStackViewAlignment.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Tom van Zummeren. All rights reserved.
 //
 
-public enum TZStackViewAlignment {
+@objc public enum TZStackViewAlignment: Int {
     case Fill
     case Center
     case Leading

--- a/Example/TZStackView-Example/TZStackView/TZStackViewDistribution.swift
+++ b/Example/TZStackView-Example/TZStackView/TZStackViewDistribution.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Tom van Zummeren. All rights reserved.
 //
 
-public enum TZStackViewDistribution {
+@objc public enum TZStackViewDistribution: Int {
     case Fill
     case FillEqually
     case FillProportionally


### PR DESCRIPTION
Expose TZStackViewAlignment and TZStackViewDistribution enums so that it can be used in objective-c code.
