### PR TITLE
Ensure subview consistency

### DIFF
--- a/Example/TZStackView-Example/TZStackView/TZStackView.swift
+++ b/Example/TZStackView-Example/TZStackView/TZStackView.swift
@@ -161,8 +161,14 @@ public class TZStackView: UIView {
     }
 
     public func insertArrangedSubview(view: UIView, atIndex stackIndex: Int) {
+		view.setTranslatesAutoresizingMaskIntoConstraints(false)
+		addSubview(view)
         arrangedSubviews.insert(view, atIndex: stackIndex)
     }
+	
+	override public func willRemoveSubview(subview: UIView) {
+		removeArrangedSubview(subview)
+	}
 
     override public func updateConstraints() {
         removeConstraints(stackViewConstraints)

--- a/Tests/TZStackView/TZStackView.swift
+++ b/Tests/TZStackView/TZStackView.swift
@@ -95,7 +95,8 @@ class TZStackView: UIView {
         }
     }
 
-    override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [NSObject : AnyObject]?, context: UnsafeMutablePointer<Void>) {
+
+	override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
         guard keyPath != nil else {
             super.observeValueForKeyPath(keyPath, ofObject: object, change: change, context: context)
             return
@@ -152,6 +153,8 @@ class TZStackView: UIView {
     }
     
     func addArrangedSubview(view: UIView) {
+		view.translatesAutoresizingMaskIntoConstraints = false
+		addSubview(view)
         _arrangedSubviews.append(view)
     }
     
@@ -162,8 +165,14 @@ class TZStackView: UIView {
     }
 
     func insertArrangedSubview(view: UIView, atIndex stackIndex: Int) {
+		view.translatesAutoresizingMaskIntoConstraints = false
+		addSubview(view)
         _arrangedSubviews.insert(view, atIndex: stackIndex)
     }
+	
+	override func willRemoveSubview(subview: UIView) {
+		removeArrangedSubview(subview)
+	}
 
     override func updateConstraints() {
         removeConstraints(stackViewConstraints)

--- a/Tests/TZStackViewTests/TZStackViewTestCase.swift
+++ b/Tests/TZStackViewTests/TZStackViewTestCase.swift
@@ -92,7 +92,23 @@ class TZStackViewTestCase: XCTestCase {
             assertSameConstraints(uiConstraints, tzConstraints)
         }
     }
-    
+	
+	func verifyArrangedSubviewConsistency() {
+		XCTAssertEqual(uiStackView.arrangedSubviews.count, tzStackView.arrangedSubviews.count, "Number of arranged subviews")
+	
+		let uiArrangedSubviews = uiStackView.arrangedSubviews as! [TestView]
+		let tzArrangedSubviews = tzStackView.arrangedSubviews as! [TestView]
+		
+		assertSameOrder(uiArrangedSubviews, tzArrangedSubviews)
+		
+		for tzTestView in tzArrangedSubviews {
+			let result = tzStackView.subviews.contains(tzTestView)
+			
+			XCTAssertTrue(result, "\(tzTestView.description) is in arranged subviews but is not actually a subview")
+		}
+	}
+	
+	
     private func nonContentSizeLayoutConstraints(view: UIView) -> [NSLayoutConstraint] {
         return view.constraints.filter({ "\($0.dynamicType)" != "NSContentSizeLayoutConstraint" })
     }
@@ -112,7 +128,17 @@ class TZStackViewTestCase: XCTestCase {
             XCTAssertTrue(result, "Constraints at index \(index) do not match\n== EXPECTED ==\n\(uiConstraint.readableString())\n\n== ACTUAL ==\n\(tzConstraint.readableString())\n\n")
         }
     }
-    
+	
+	func assertSameOrder(uiTestViews: [TestView], _ tzTestViews: [TestView]) {
+		for (index, uiTestView) in uiTestViews.enumerate() {
+			let tzTestView = tzTestViews[index]
+			
+			let result = uiTestView.index == tzTestView.index
+			
+			XCTAssertTrue(result, "Views at index \(index) do not match\n== EXPECTED ==\n\(uiTestView.description)\n\n== ACTUAL ==\n\(tzTestView.description)\n\n")
+		}
+	}
+	
     private func hasSameConstraintMetaData(layoutConstraint1: NSLayoutConstraint, _ layoutConstraint2: NSLayoutConstraint) -> Bool {
         if layoutConstraint1.constant != layoutConstraint2.constant {
             return false

--- a/Tests/TZStackViewTests/TZStackViewTests.swift
+++ b/Tests/TZStackViewTests/TZStackViewTests.swift
@@ -1150,4 +1150,47 @@ class TZStackViewTests: TZStackViewTestCase {
         
         verifyConstraints()
     }
+	
+	
+	// MARK: - Maintaining Consistency Between the Arranged Views and Subviews
+	// https://developer.apple.com/library/prerelease/ios/documentation/UIKit/Reference/UIStackView_Class_Reference/#//apple_ref/doc/uid/TP40015256-CH1-SW29
+	func testConsistencyWhenAddingArrangedSubview() {
+		let uiTestView = TestView(index: -1, size: CGSize(width: 100, height: 100))
+		uiStackView.addArrangedSubview(uiTestView)
+		
+		let tzTestView = TestView(index: -1, size: CGSize(width: 100, height: 100))
+		tzStackView.addArrangedSubview(tzTestView)
+		
+		verifyArrangedSubviewConsistency()
+	}
+
+	func testConsistencyWhenInsertingArrangedSubview() {
+		let uiTestView = TestView(index: -1, size: CGSize(width: 100, height: 100))
+		uiStackView.insertArrangedSubview(uiTestView, atIndex: 0)
+		
+		let tzTestView = TestView(index: -1, size: CGSize(width: 100, height: 100))
+		tzStackView.insertArrangedSubview(tzTestView, atIndex: 0)
+		
+		verifyArrangedSubviewConsistency()
+	}
+	
+	func testConsistencyWhenRemovingArrangedSubview() {
+		let uiTestView = uiStackView.arrangedSubviews.last
+		uiStackView.removeArrangedSubview(uiTestView!)
+		
+		let tzTestView = tzStackView.arrangedSubviews.last
+		tzStackView.removeArrangedSubview(tzTestView!)
+		
+		verifyArrangedSubviewConsistency()
+	}
+	
+	func testConsistencyWhenRemovingSubview() {
+		let uiTestView = uiStackView.arrangedSubviews.last
+		uiTestView!.removeFromSuperview()
+		
+		let tzTestView = tzStackView.arrangedSubviews.last
+		tzTestView!.removeFromSuperview()
+		
+		verifyArrangedSubviewConsistency()
+	}
 }


### PR DESCRIPTION
The UIStackView [documentation](https://developer.apple.com/library/prerelease/ios/documentation/UIKit/Reference/UIStackView_Class_Reference/#//apple_ref/doc/uid/TP40015256-CH1-SW29) specifies rules for the consistency between arranged subviews and subviews.

In short
- Arranged subviews is a subset of subviews so anytime a view is added to the arranged subviews it should also be added as a subview.
- Every time a subview is removed from the stack view it should also be removed from the arranged subviews if necessary.

Currently TZStackView does not conform to these rules. This PR aims to address that.
Not all tests pass as it looks like UIStackView has changed since they were originally written (see https://github.com/tomvanzummeren/TZStackView/issues/21) but the tests I've written to verify the consistency worked when ran against beta 4
