### PR TITLE
Added import Foundation before using @objc

### DIFF
--- a/Example/TZStackView-Example/TZStackView/TZStackViewAlignment.swift
+++ b/Example/TZStackView-Example/TZStackView/TZStackViewAlignment.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2015 Tom van Zummeren. All rights reserved.
 //
 
+import Foundation
+
 @objc public enum TZStackViewAlignment: Int {
     case Fill
     case Center

--- a/Example/TZStackView-Example/TZStackView/TZStackViewDistribution.swift
+++ b/Example/TZStackView-Example/TZStackView/TZStackViewDistribution.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2015 Tom van Zummeren. All rights reserved.
 //
 
+import Foundation
+
 @objc public enum TZStackViewDistribution: Int {
     case Fill
     case FillEqually


### PR DESCRIPTION
When compiling the example project in Xcode 7 beta 5 I got a compiler error: "@objc attribute used without importing module 'Foundation'"
