### PR TITLE
Enabled the application extension API only build setting.

### DIFF
--- a/Example/TZStackView-Example.xcodeproj/project.pbxproj
+++ b/Example/TZStackView-Example.xcodeproj/project.pbxproj
@@ -302,6 +302,7 @@
 		9ECA23871B6B59D8003C2AEC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -323,6 +324,7 @@
 		9ECA23881B6B59D8003C2AEC /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;


### PR DESCRIPTION
Since `TZStackView` is already extension-api-safe, I enabled the build setting `APPLICATION_EXTENSION_API_ONLY` which enables the framework to be built and used in extension without warnings and errors. It's quite useful in today and keyboard extensions.
