### PR TITLE
Fix layoutMarginsRelativeArrangement to align to margin attributes

### DIFF
--- a/TZStackView/TZStackView.swift
+++ b/TZStackView/TZStackView.swift
@@ -317,10 +317,10 @@ public class TZStackView: UIView {
 
             if layoutMarginsRelativeArrangement {
                 if spacerViews.count > 0 {
-                    stackViewConstraints.append(constraint(item: self, attribute: .Bottom, toItem: spacerViews[0]))
-                    stackViewConstraints.append(constraint(item: self, attribute: .Left, toItem: spacerViews[0]))
-                    stackViewConstraints.append(constraint(item: self, attribute: .Right, toItem: spacerViews[0]))
-                    stackViewConstraints.append(constraint(item: self, attribute: .Top, toItem: spacerViews[0]))
+                    stackViewConstraints.append(constraint(item: self, attribute: .BottomMargin, toItem: spacerViews[0]))
+                    stackViewConstraints.append(constraint(item: self, attribute: .LeftMargin, toItem: spacerViews[0]))
+                    stackViewConstraints.append(constraint(item: self, attribute: .RightMargin, toItem: spacerViews[0]))
+                    stackViewConstraints.append(constraint(item: self, attribute: .TopMargin, toItem: spacerViews[0]))
                 }
             }
             addConstraints(stackViewConstraints)


### PR DESCRIPTION
From Apple's docs:

> If you set the stack view’s layoutMarginsRelativeArrangement property to true, the stack view pins its content to the relevant margin instead of its edge.

Also:

> If true, the stack view will layout its arranged views relative to its layout margins. If false, it lays out the arranged views relative to its bounds. The default is false.

This fixes an issue @nomadplanet mentioned: https://github.com/tomvanzummeren/TZStackView/issues/17#issuecomment-141374027
