### PR TITLE
Bug Fix for animating views hidden / visible

### DIFF
--- a/TZStackView/TZStackView.swift
+++ b/TZStackView/TZStackView.swift
@@ -107,6 +107,8 @@ public class TZStackView: UIView {
             }
             // Perform the animation
             setNeedsUpdateConstraints()
+            updateConstraintsIfNeeded()
+            
             setNeedsLayout()
             layoutIfNeeded()
             


### PR DESCRIPTION
I've noticed that nested stack views don't always animate to / from hidden correctly. This pull request addresses that.
