### PR TITLE
first pass implementation of problem in #20

### DIFF
--- a/TZStackView.xcodeproj/project.pbxproj
+++ b/TZStackView.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		5F50E6EAC8DDE44079E03638 /* TZStackViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F50EDEB0947F99E67140FC6 /* TZStackViewTests.swift */; };
 		5F50E81C644B9C88791038B0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F50EF54F01A3A6938C6CEA1 /* AppDelegate.swift */; };
-		5F50E83B164FAE28B52A5A91 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F50ECF2FC09D64EB02F1309 /* ViewController.swift */; };
 		5F50E9F2F7E5B2DA68C946E0 /* ExplicitIntrinsicContentSizeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F50E5EB8202F5247F8517F3 /* ExplicitIntrinsicContentSizeView.swift */; };
 		5F50EAD959E8ACC5929DBD75 /* NSLayoutConstraintExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB41AF691B294B8E003DB902 /* NSLayoutConstraintExtension.swift */; };
 		5F50EF474D670FC33E8E80EA /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5F50ED5A43FBFC32B9B9E1AA /* Images.xcassets */; };
@@ -20,6 +19,10 @@
 		A45441D11B9B6D9C002452BA /* TZStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45441CD1B9B6D9C002452BA /* TZStackView.swift */; settings = {ASSET_TAGS = (); }; };
 		A45441D21B9B6D9C002452BA /* TZStackViewAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45441CE1B9B6D9C002452BA /* TZStackViewAlignment.swift */; settings = {ASSET_TAGS = (); }; };
 		A45441D31B9B6D9C002452BA /* TZStackViewDistribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45441CF1B9B6D9C002452BA /* TZStackViewDistribution.swift */; settings = {ASSET_TAGS = (); }; };
+		DA006A7C1BBC308F00EEF37A /* ExplicitIntrinsicContentSizeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F50E5EB8202F5247F8517F3 /* ExplicitIntrinsicContentSizeView.swift */; settings = {ASSET_TAGS = (); }; };
+		DA55BC161BBC21FD008C57B2 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA55BC141BBC21FD008C57B2 /* ViewController.swift */; settings = {ASSET_TAGS = (); }; };
+		DA55BC171BBC21FD008C57B2 /* ViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DA55BC151BBC21FD008C57B2 /* ViewController.xib */; settings = {ASSET_TAGS = (); }; };
+		DA55BC191BBC22B6008C57B2 /* TZStackViewIB.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA55BC181BBC22B6008C57B2 /* TZStackViewIB.swift */; settings = {ASSET_TAGS = (); }; };
 		DB41AF6A1B294B8E003DB902 /* NSLayoutConstraintExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB41AF691B294B8E003DB902 /* NSLayoutConstraintExtension.swift */; };
 		DB5B70851B2A1963006043BD /* TestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5B70841B2A1963006043BD /* TestView.swift */; };
 		DB5B70871B2B8816006043BD /* TZStackViewTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5B70861B2B8816006043BD /* TZStackViewTestCase.swift */; };
@@ -62,7 +65,6 @@
 		5F50E5EB8202F5247F8517F3 /* ExplicitIntrinsicContentSizeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExplicitIntrinsicContentSizeView.swift; sourceTree = "<group>"; };
 		5F50E9955790F6814D494857 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.info; path = Info.plist; sourceTree = "<group>"; };
 		5F50ECE89FF2DA8F6B16DB3E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.info; path = Info.plist; sourceTree = "<group>"; };
-		5F50ECF2FC09D64EB02F1309 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		5F50ED5A43FBFC32B9B9E1AA /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		5F50EDEB0947F99E67140FC6 /* TZStackViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TZStackViewTests.swift; sourceTree = "<group>"; };
 		5F50EF54F01A3A6938C6CEA1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -74,6 +76,9 @@
 		A45441CD1B9B6D9C002452BA /* TZStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TZStackView.swift; sourceTree = "<group>"; };
 		A45441CE1B9B6D9C002452BA /* TZStackViewAlignment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TZStackViewAlignment.swift; sourceTree = "<group>"; };
 		A45441CF1B9B6D9C002452BA /* TZStackViewDistribution.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TZStackViewDistribution.swift; sourceTree = "<group>"; };
+		DA55BC141BBC21FD008C57B2 /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		DA55BC151BBC21FD008C57B2 /* ViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ViewController.xib; sourceTree = "<group>"; };
+		DA55BC181BBC22B6008C57B2 /* TZStackViewIB.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TZStackViewIB.swift; sourceTree = "<group>"; };
 		DB41AF691B294B8E003DB902 /* NSLayoutConstraintExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSLayoutConstraintExtension.swift; sourceTree = "<group>"; };
 		DB5B70841B2A1963006043BD /* TestView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestView.swift; sourceTree = "<group>"; };
 		DB5B70861B2B8816006043BD /* TZStackViewTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TZStackViewTestCase.swift; sourceTree = "<group>"; };
@@ -149,7 +154,8 @@
 			isa = PBXGroup;
 			children = (
 				5F50EF54F01A3A6938C6CEA1 /* AppDelegate.swift */,
-				5F50ECF2FC09D64EB02F1309 /* ViewController.swift */,
+				DA55BC141BBC21FD008C57B2 /* ViewController.swift */,
+				DA55BC151BBC21FD008C57B2 /* ViewController.xib */,
 				5F50E5EB8202F5247F8517F3 /* ExplicitIntrinsicContentSizeView.swift */,
 				DB41AF691B294B8E003DB902 /* NSLayoutConstraintExtension.swift */,
 				DB614E5D1B292B630024E8AD /* LaunchScreen.xib */,
@@ -172,6 +178,7 @@
 			children = (
 				A45441CC1B9B6D9C002452BA /* TZSpacerView.swift */,
 				A45441CD1B9B6D9C002452BA /* TZStackView.swift */,
+				DA55BC181BBC22B6008C57B2 /* TZStackViewIB.swift */,
 				A45441CE1B9B6D9C002452BA /* TZStackViewAlignment.swift */,
 				A45441CF1B9B6D9C002452BA /* TZStackViewDistribution.swift */,
 				A45441D41B9B6E46002452BA /* Supporting Files */,
@@ -297,6 +304,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DB614E5E1B292B630024E8AD /* LaunchScreen.xib in Resources */,
+				DA55BC171BBC21FD008C57B2 /* ViewController.xib in Resources */,
 				5F50EF474D670FC33E8E80EA /* Images.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -335,7 +343,7 @@
 			files = (
 				5F50E81C644B9C88791038B0 /* AppDelegate.swift in Sources */,
 				DB41AF6A1B294B8E003DB902 /* NSLayoutConstraintExtension.swift in Sources */,
-				5F50E83B164FAE28B52A5A91 /* ViewController.swift in Sources */,
+				DA55BC161BBC21FD008C57B2 /* ViewController.swift in Sources */,
 				5F50E9F2F7E5B2DA68C946E0 /* ExplicitIntrinsicContentSizeView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -344,6 +352,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA55BC191BBC22B6008C57B2 /* TZStackViewIB.swift in Sources */,
+				DA006A7C1BBC308F00EEF37A /* ExplicitIntrinsicContentSizeView.swift in Sources */,
 				A45441D21B9B6D9C002452BA /* TZStackViewAlignment.swift in Sources */,
 				A45441D01B9B6D9C002452BA /* TZSpacerView.swift in Sources */,
 				A45441D11B9B6D9C002452BA /* TZStackView.swift in Sources */,

--- a/TZStackView/TZStackView.swift
+++ b/TZStackView/TZStackView.swift
@@ -17,6 +17,7 @@ func ==(lhs: TZAnimationDidStopQueueEntry, rhs: TZAnimationDidStopQueueEntry) ->
     return lhs.view === rhs.view
 }
 
+@IBDesignable
 public class TZStackView: UIView {
 
     public var distribution: TZStackViewDistribution = .Fill {
@@ -37,7 +38,7 @@ public class TZStackView: UIView {
     
     public var layoutMarginsRelativeArrangement = false
 
-    public private(set) var arrangedSubviews: [UIView] = [] {
+    public var arrangedSubviews: [UIView] = [] {
         didSet {
             setNeedsUpdateConstraints()
             registerHiddenListeners(oldValue)
@@ -57,6 +58,10 @@ public class TZStackView: UIView {
     
     private var animatingToHiddenViews = [UIView]()
 
+    public override init(frame: CGRect) {
+        super.init(frame: CGRectZero)
+    }
+    
     public init(arrangedSubviews: [UIView] = []) {
         super.init(frame: CGRectZero)
         for arrangedSubview in arrangedSubviews {
@@ -329,6 +334,10 @@ public class TZStackView: UIView {
         super.updateConstraints()
     }
 
+    override public func prepareForInterfaceBuilder() {
+        
+    }
+    
     required public init(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)!
     }

--- a/TZStackView/TZStackViewIB.swift
+++ b/TZStackView/TZStackViewIB.swift
@@ -1,0 +1,81 @@
+//
+//  TZStackViewIB.swift
+//  TZStackView
+//
+//  Created by Paul Jones on 9/30/15.
+//  Copyright © 2015 Tom van Zummeren. All rights reserved.
+//
+
+
+extension TZStackView {
+    @IBInspectable var ibDistribution: Int {
+        set(newValue) {
+            self.distribution = TZStackViewDistribution(rawValue: newValue)!
+        }
+        get {
+            return self.distribution.rawValue
+        }
+    }
+    
+    @IBInspectable var ibAxis: Int {
+        set(newValue) {
+            self.axis = UILayoutConstraintAxis(rawValue: newValue)!
+        }
+        get {
+            return self.axis.rawValue
+        }
+    }
+    
+    @IBInspectable var ibAlignment: Int {
+        set(newValue) {
+            self.alignment = TZStackViewAlignment(rawValue: newValue)!
+        }
+        get {
+            return self.alignment.rawValue
+        }
+    }
+    
+    @IBInspectable var ibSpacing: CGFloat {
+        set(newValue) {
+            self.spacing = newValue
+        }
+        get {
+            return self.spacing
+        }
+    }
+    
+    @IBInspectable var numberOfArrangedSubviews: Int {
+        set(newValue) {
+            
+            #if !TARGET_INTERFACE_BUILDER
+                for view in self.subviews {
+                    view.removeFromSuperview()
+                    self.addSubview(view)
+                }
+                self.arrangedSubviews = self.subviews
+                #else
+                var views = Array<UIView>()
+                for view in self.subviews {
+                    view.removeFromSuperview()
+                }
+                
+                for _ in 0...newValue {
+                    let view = ExplicitIntrinsicContentSizeView(intrinsicContentSize: CGSizeMake(100, 100), name: "Hello")
+                    view.backgroundColor = UIColor.blueColor()
+                    views.append(view)
+                }
+                
+                for arrangedSubview in views {
+                    arrangedSubview.translatesAutoresizingMaskIntoConstraints = false
+                    self.addSubview(arrangedSubview)
+                }
+                
+                self.arrangedSubviews = views
+            #endif
+            
+        }
+        get {
+            return self.arrangedSubviews.count
+        }
+    }
+}

--- a/TZStackViewDemo/ExplicitIntrinsicContentSizeView.swift
+++ b/TZStackViewDemo/ExplicitIntrinsicContentSizeView.swift
@@ -27,7 +27,9 @@ class ExplicitIntrinsicContentSizeView: UIView {
     }
 
     required init(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        self.name = ""
+        self.contentSize = CGSizeMake(100, 100)
+        super.init(coder: aDecoder)!
     }
 
     override func intrinsicContentSize() -> CGSize {

--- a/TZStackViewDemo/LaunchScreen.xib
+++ b/TZStackViewDemo/LaunchScreen.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6214" systemVersion="14A314h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
     </dependencies>
     <objects>

--- a/TZStackViewDemo/ViewController.swift
+++ b/TZStackViewDemo/ViewController.swift
@@ -1,183 +1,43 @@
 //
 //  ViewController.swift
-//  TZStackView-Example
+//  TZStackView
 //
-//  Created by Tom van Zummeren on 20/06/15.
-//  Copyright (c) 2015 Tom van Zummeren. All rights reserved.
+//  Created by Paul Jones on 9/30/15.
+//  Copyright © 2015 Tom van Zummeren. All rights reserved.
 //
 
 import UIKit
-
 import TZStackView
 
 class ViewController: UIViewController {
-    //MARK: - Properties
-    //--------------------------------------------------------------------------
-    var tzStackView: TZStackView!
 
-    let resetButton = UIButton(type: .System)
-    let instructionLabel = UILabel()
-
-    var axisSegmentedControl: UISegmentedControl!
-    var alignmentSegmentedControl: UISegmentedControl!
-    var distributionSegmentedControl: UISegmentedControl!
-
-    //MARK: - Lifecyle
-    //--------------------------------------------------------------------------
+    @IBOutlet var stackView: TZStackView!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        edgesForExtendedLayout = .None;
-
-        view.backgroundColor = UIColor.blackColor()
-        title = "TZStackView"
-
-        tzStackView = TZStackView(arrangedSubviews: createViews())
-        tzStackView.translatesAutoresizingMaskIntoConstraints = false
-        tzStackView.axis = .Vertical
-        tzStackView.distribution = .Fill
-        tzStackView.alignment = .Fill
-        tzStackView.spacing = 15
-        view.addSubview(tzStackView)
-
-        instructionLabel.translatesAutoresizingMaskIntoConstraints = false
-        instructionLabel.font = UIFont.systemFontOfSize(15)
-        instructionLabel.text = "Tap any of the boxes to set hidden=true"
-        instructionLabel.textColor = UIColor.whiteColor()
-        instructionLabel.numberOfLines = 0
-        instructionLabel.setContentCompressionResistancePriority(900, forAxis: .Horizontal)
-        instructionLabel.setContentHuggingPriority(1000, forAxis: .Vertical)
-        view.addSubview(instructionLabel)
-
-        resetButton.translatesAutoresizingMaskIntoConstraints = false
-        resetButton.setTitle("Reset", forState: .Normal)
-        resetButton.addTarget(self, action: "reset", forControlEvents: .TouchUpInside)
-        resetButton.setContentCompressionResistancePriority(1000, forAxis: .Horizontal)
-        resetButton.setContentHuggingPriority(1000, forAxis: .Horizontal)
-        resetButton.setContentHuggingPriority(1000, forAxis: .Vertical)
-        view.addSubview(resetButton)
-
-        axisSegmentedControl = UISegmentedControl(items: ["Vertical", "Horizontal"])
-        axisSegmentedControl.selectedSegmentIndex = 0
-        axisSegmentedControl.addTarget(self, action: "axisChanged:", forControlEvents: .ValueChanged)
-        axisSegmentedControl.setContentCompressionResistancePriority(900, forAxis: .Horizontal)
-        axisSegmentedControl.tintColor = UIColor.lightGrayColor()
-
-        alignmentSegmentedControl = UISegmentedControl(items: ["Fill", "Center", "Leading", "Top", "Trailing", "Bottom", "FirstBaseline"])
-        alignmentSegmentedControl.selectedSegmentIndex = 0
-        alignmentSegmentedControl.addTarget(self, action: "alignmentChanged:", forControlEvents: .ValueChanged)
-        alignmentSegmentedControl.setContentCompressionResistancePriority(1000, forAxis: .Horizontal)
-        alignmentSegmentedControl.tintColor = UIColor.lightGrayColor()
-
-        distributionSegmentedControl = UISegmentedControl(items: ["Fill", "FillEqually", "FillProportionally", "EqualSpacing", "EqualCentering"])
-        distributionSegmentedControl.selectedSegmentIndex = 0
-        distributionSegmentedControl.addTarget(self, action: "distributionChanged:", forControlEvents: .ValueChanged)
-        distributionSegmentedControl.tintColor = UIColor.lightGrayColor()
-
-        let controlsLayoutContainer = TZStackView(arrangedSubviews: [axisSegmentedControl, alignmentSegmentedControl, distributionSegmentedControl])
-        controlsLayoutContainer.axis = .Vertical
-        controlsLayoutContainer.translatesAutoresizingMaskIntoConstraints = false
-        controlsLayoutContainer.spacing = 5
-        controlsLayoutContainer.setContentHuggingPriority(1000, forAxis: .Vertical)
-        view.addSubview(controlsLayoutContainer)
-
-        let views: [String:AnyObject] = [
-                "instructionLabel": instructionLabel,
-                "resetButton": resetButton,
-                "tzStackView": tzStackView,
-                "controlsLayoutContainer": controlsLayoutContainer
-        ]
-
-        let metrics: [String:AnyObject] = [
-                "gap": 10,
-                "topspacing": 25
-        ]
-
-        view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|-gap-[instructionLabel]-[resetButton]-gap-|",
-                options: NSLayoutFormatOptions(rawValue: 0), metrics: metrics, views: views))
-        view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|[tzStackView]|",
-                options: NSLayoutFormatOptions(rawValue: 0), metrics: metrics, views: views))
-        view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|[controlsLayoutContainer]|",
-                options: NSLayoutFormatOptions(rawValue: 0), metrics: metrics, views: views))
-
-        view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|-topspacing-[instructionLabel]-gap-[controlsLayoutContainer]-gap-[tzStackView]|",
-                options: NSLayoutFormatOptions(rawValue: 0), metrics: metrics, views: views))
-        view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|-topspacing-[resetButton]-gap-[controlsLayoutContainer]",
-                options: NSLayoutFormatOptions(rawValue: 0), metrics: metrics, views: views))
+        // Do any additional setup after loading the view.
     }
 
-    private func createViews() -> [UIView] {
-        let redView = ExplicitIntrinsicContentSizeView(intrinsicContentSize: CGSize(width: 100, height: 100), name: "Red")
-        let greenView = ExplicitIntrinsicContentSizeView(intrinsicContentSize: CGSize(width: 80, height: 80), name: "Green")
-        let blueView = ExplicitIntrinsicContentSizeView(intrinsicContentSize: CGSize(width: 60, height: 60), name: "Blue")
-        let purpleView = ExplicitIntrinsicContentSizeView(intrinsicContentSize: CGSize(width: 80, height: 80), name: "Purple")
-        let yellowView = ExplicitIntrinsicContentSizeView(intrinsicContentSize: CGSize(width: 100, height: 100), name: "Yellow")
-
-        redView.backgroundColor = UIColor.redColor().colorWithAlphaComponent(0.75)
-        greenView.backgroundColor = UIColor.greenColor().colorWithAlphaComponent(0.75)
-        blueView.backgroundColor = UIColor.blueColor().colorWithAlphaComponent(0.75)
-        purpleView.backgroundColor = UIColor.purpleColor().colorWithAlphaComponent(0.75)
-        yellowView.backgroundColor = UIColor.yellowColor().colorWithAlphaComponent(0.75)
-        return [redView, greenView, blueView, purpleView, yellowView]
+    override func viewDidAppear(animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        
     }
-
-    //MARK: - Button Actions
-    //--------------------------------------------------------------------------
-    func reset() {
-        UIView.animateWithDuration(0.6, delay: 0, usingSpringWithDamping: 0.7, initialSpringVelocity: 0, options: .AllowUserInteraction, animations: {
-            for view in self.tzStackView.arrangedSubviews {
-                view.hidden = false
-            }
-        }, completion: nil)
-
+    
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
     }
+    
 
-    //MARK: - Segmented Control Actions
-    //--------------------------------------------------------------------------
-    func axisChanged(sender: UISegmentedControl) {
-        switch sender.selectedSegmentIndex {
-        case 0:
-            tzStackView.axis = .Vertical
-        default:
-            tzStackView.axis = .Horizontal
-        }
-    }
+    /*
+    // MARK: - Navigation
 
-    func alignmentChanged(sender: UISegmentedControl) {
-        switch sender.selectedSegmentIndex {
-        case 0:
-            tzStackView.alignment = .Fill
-        case 1:
-            tzStackView.alignment = .Center
-        case 2:
-            tzStackView.alignment = .Leading
-        case 3:
-            tzStackView.alignment = .Top
-        case 4:
-            tzStackView.alignment = .Trailing
-        case 5:
-            tzStackView.alignment = .Bottom
-        default:
-            tzStackView.alignment = .FirstBaseline
-        }
-        tzStackView.setNeedsUpdateConstraints()
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
+        // Get the new view controller using segue.destinationViewController.
+        // Pass the selected object to the new view controller.
     }
+    */
 
-    func distributionChanged(sender: UISegmentedControl) {
-        switch sender.selectedSegmentIndex {
-        case 0:
-            tzStackView.distribution = .Fill
-        case 1:
-            tzStackView.distribution = .FillEqually
-        case 2:
-            tzStackView.distribution = .FillProportionally
-        case 3:
-            tzStackView.distribution = .EqualSpacing
-        default:
-            tzStackView.distribution = .EqualCentering
-        }
-    }
-
-    override func preferredStatusBarStyle() -> UIStatusBarStyle {
-        return .LightContent
-    }
 }

--- a/TZStackViewDemo/ViewController.xib
+++ b/TZStackViewDemo/ViewController.xib
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8191"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ViewController" customModule="TZStackViewDemo" customModuleProvider="target">
+            <connections>
+                <outlet property="stackView" destination="arZ-kq-6v9" id="vkq-2R-BKp"/>
+                <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="arZ-kq-6v9" customClass="TZStackView" customModule="TZStackView">
+                    <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GZL-vT-RLg" customClass="ExplicitIntrinsicContentSizeView" customModule="TZStackViewDemo" customModuleProvider="target">
+                            <rect key="frame" x="8" y="29" width="240" height="128"/>
+                            <color key="backgroundColor" red="0.59999999999999998" green="0.51764705879999995" blue="0.2470588235" alpha="1" colorSpace="calibratedRGB"/>
+                        </view>
+                        <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3s9-EO-z2g" customClass="ExplicitIntrinsicContentSizeView" customModule="TZStackViewDemo" customModuleProvider="target">
+                            <rect key="frame" x="352" y="389" width="240" height="128"/>
+                            <color key="backgroundColor" red="0.59999999999999998" green="0.51764705879999995" blue="0.2470588235" alpha="1" colorSpace="calibratedRGB"/>
+                        </view>
+                        <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PRv-HY-WPB" customClass="ExplicitIntrinsicContentSizeView" customModule="TZStackViewDemo" customModuleProvider="target">
+                            <rect key="frame" x="-6" y="201" width="240" height="128"/>
+                            <color key="backgroundColor" red="0.59999999999999998" green="0.51764705879999995" blue="0.2470588235" alpha="1" colorSpace="calibratedRGB"/>
+                        </view>
+                        <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aiQ-UL-vBH" customClass="ExplicitIntrinsicContentSizeView" customModule="TZStackViewDemo" customModuleProvider="target">
+                            <rect key="frame" x="352" y="115" width="240" height="128"/>
+                            <color key="backgroundColor" red="0.59999999999999998" green="0.51764705879999995" blue="0.2470588235" alpha="1" colorSpace="calibratedRGB"/>
+                        </view>
+                    </subviews>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="numberOfArrangedSubviews">
+                            <integer key="value" value="3"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="number" keyPath="ibSpacing">
+                            <real key="value" value="6"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="number" keyPath="ibAlignment">
+                            <integer key="value" value="1"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="number" keyPath="ibAxis">
+                            <integer key="value" value="1"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="number" keyPath="ibDistribution">
+                            <integer key="value" value="0"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                </view>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="arZ-kq-6v9" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="7Ng-fA-gcB"/>
+                <constraint firstAttribute="bottom" secondItem="arZ-kq-6v9" secondAttribute="bottom" id="8CK-8g-iYT"/>
+                <constraint firstItem="arZ-kq-6v9" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="WnY-xn-foN"/>
+                <constraint firstAttribute="trailing" secondItem="arZ-kq-6v9" secondAttribute="trailing" id="fnK-8V-cHr"/>
+            </constraints>
+            <point key="canvasLocation" x="-181" y="307"/>
+        </view>
+    </objects>
+</document>


### PR DESCRIPTION
This PR represents one possible way to implement Interface Builder support for `TZStackView`. The strategy taken here was: 
1. Make all the necessary parameters configurable through `IBInspectable`. This is relatively inoffensive (aside from being delicate because Xcode can't have enumerated types as IBInspectable) and makes for a nice addition.
2. At design time, insert nonsense subviews into the hierarchy to preview the behavior of the stack view. At run time, convert any subviews into `arrangedSubviews`. This is a bit more controversial. 

Ultimately, I think this code as it stands is not production ready. However, I think it's a good starting point to discuss how to implement this feature.
