### PR TITLE
UIStackView replacement for Nib/Storyboard support

### DIFF
--- a/TZStackView.podspec
+++ b/TZStackView.podspec
@@ -9,5 +9,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.ios.deployment_target = "8.0"
   s.source   = { :git => "https://github.com/tomvanzummeren/TZStackView.git", :tag => "1.1.2"}
-  s.source_files = "TZStackView/*.swift"
+s.source_files = "TZStackView/*.{m,swift}"
 end

--- a/TZStackView.xcodeproj/project.pbxproj
+++ b/TZStackView.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		A45441D11B9B6D9C002452BA /* TZStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45441CD1B9B6D9C002452BA /* TZStackView.swift */; settings = {ASSET_TAGS = (); }; };
 		A45441D21B9B6D9C002452BA /* TZStackViewAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45441CE1B9B6D9C002452BA /* TZStackViewAlignment.swift */; settings = {ASSET_TAGS = (); }; };
 		A45441D31B9B6D9C002452BA /* TZStackViewDistribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45441CF1B9B6D9C002452BA /* TZStackViewDistribution.swift */; settings = {ASSET_TAGS = (); }; };
+		AAA6E7D11BD16AEF00C1685B /* TZStackView.m in Sources */ = {isa = PBXBuildFile; fileRef = AAA6E7D01BD16AEF00C1685B /* TZStackView.m */; settings = {ASSET_TAGS = (); }; };
 		DB41AF6A1B294B8E003DB902 /* NSLayoutConstraintExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB41AF691B294B8E003DB902 /* NSLayoutConstraintExtension.swift */; };
 		DB5B70851B2A1963006043BD /* TestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5B70841B2A1963006043BD /* TestView.swift */; };
 		DB5B70871B2B8816006043BD /* TZStackViewTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5B70861B2B8816006043BD /* TZStackViewTestCase.swift */; };
@@ -74,6 +75,7 @@
 		A45441CD1B9B6D9C002452BA /* TZStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TZStackView.swift; sourceTree = "<group>"; };
 		A45441CE1B9B6D9C002452BA /* TZStackViewAlignment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TZStackViewAlignment.swift; sourceTree = "<group>"; };
 		A45441CF1B9B6D9C002452BA /* TZStackViewDistribution.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TZStackViewDistribution.swift; sourceTree = "<group>"; };
+		AAA6E7D01BD16AEF00C1685B /* TZStackView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TZStackView.m; sourceTree = "<group>"; };
 		DB41AF691B294B8E003DB902 /* NSLayoutConstraintExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSLayoutConstraintExtension.swift; sourceTree = "<group>"; };
 		DB5B70841B2A1963006043BD /* TestView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestView.swift; sourceTree = "<group>"; };
 		DB5B70861B2B8816006043BD /* TZStackViewTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TZStackViewTestCase.swift; sourceTree = "<group>"; };
@@ -175,6 +177,7 @@
 				A45441CE1B9B6D9C002452BA /* TZStackViewAlignment.swift */,
 				A45441CF1B9B6D9C002452BA /* TZStackViewDistribution.swift */,
 				A45441D41B9B6E46002452BA /* Supporting Files */,
+				AAA6E7D01BD16AEF00C1685B /* TZStackView.m */,
 			);
 			path = TZStackView;
 			sourceTree = "<group>";
@@ -344,6 +347,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AAA6E7D11BD16AEF00C1685B /* TZStackView.m in Sources */,
 				A45441D21B9B6D9C002452BA /* TZStackViewAlignment.swift in Sources */,
 				A45441D01B9B6D9C002452BA /* TZSpacerView.swift in Sources */,
 				A45441D11B9B6D9C002452BA /* TZStackView.swift in Sources */,

--- a/TZStackView/TZStackView.m
+++ b/TZStackView/TZStackView.m
@@ -1,0 +1,75 @@
+//
+//  TZStackView.m
+//  TZStackView
+//
+//  Created by Kevin Wooten on 10/16/15.
+//  Copyright © 2015 Tom van Zummeren. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+
+// ----------------------------------------------------
+// Runtime injection start.
+// Assemble codes below are based on:
+// https://github.com/0xced/NSUUID/blob/master/NSUUID.m
+// ----------------------------------------------------
+
+#pragma mark - Runtime Injection
+
+__asm(
+      ".section        __DATA,__objc_classrefs,regular,no_dead_strip\n"
+#if	TARGET_RT_64_BIT
+      ".align          3\n"
+      "L_OBJC_CLASS_UIStackView:\n"
+      ".quad           _OBJC_CLASS_$_UIStackView\n"
+#else
+      ".align          2\n"
+      "_OBJC_CLASS_UIStackView:\n"
+      ".long           _OBJC_CLASS_$_UIStackView\n"
+#endif
+      ".weak_reference _OBJC_CLASS_$_UIStackView\n"
+      );
+
+// Constructors are called after all classes have been loaded.
+__attribute__((constructor)) static void TZStackViewPatchEntry(void) {
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    @autoreleasepool {
+      
+      // >= iOS9.
+      if (objc_getClass("UIStackView")) {
+        return;
+      }
+      
+      Class *stackViewClassLocation = NULL;
+      
+#if TARGET_CPU_ARM
+      __asm("movw %0, :lower16:(_OBJC_CLASS_UIStackView-(LPC0+4))\n"
+            "movt %0, :upper16:(_OBJC_CLASS_UIStackView-(LPC0+4))\n"
+            "LPC0: add %0, pc" : "=r"(stackViewClassLocation));
+#elif TARGET_CPU_ARM64
+      __asm("adrp %0, L_OBJC_CLASS_UIStackView@PAGE\n"
+            "add  %0, %0, L_OBJC_CLASS_UIStackView@PAGEOFF" : "=r"(stackViewClassLocation));
+#elif TARGET_CPU_X86_64
+      __asm("leaq L_OBJC_CLASS_UIStackView(%%rip), %0" : "=r"(stackViewClassLocation));
+#elif TARGET_CPU_X86
+      void *pc = NULL;
+      __asm("calll L0\n"
+            "L0: popl %0\n"
+            "leal _OBJC_CLASS_UIStackView-L0(%0), %1" : "=r"(pc), "=r"(stackViewClassLocation));
+#else
+#error Unsupported CPU
+#endif
+      
+      if (stackViewClassLocation && !*stackViewClassLocation) {
+        Class superclass = NSClassFromString(@"TZStackView") ? NSClassFromString(@"TZStackView") : NSClassFromString(@"TZStackView.TZStackView");
+        Class class = objc_allocateClassPair(superclass, "UIStackView", 0);
+        if (class) {
+          objc_registerClassPair(class);
+          *stackViewClassLocation = class;
+        }
+      }
+    }
+  });
+}

--- a/TZStackView/TZStackView.swift
+++ b/TZStackView/TZStackView.swift
@@ -503,12 +503,14 @@ public class TZStackView: UIView {
                 constraints += equalAttributes(views: views, attribute: .Top)
             case .Center:
                 constraints += equalAttributes(views: views, attribute: .CenterY)
-            case .Leading, .Top:
+            case .Leading:
                 constraints += equalAttributes(views: views, attribute: .Top)
-            case .Trailing, .Bottom:
+            case .Trailing:
                 constraints += equalAttributes(views: views, attribute: .Bottom)
             case .FirstBaseline:
                 constraints += equalAttributes(views: views, attribute: .FirstBaseline)
+            case .LastBaseline:
+                constraints += equalAttributes(views: views, attribute: .LastBaseline)
             }
             
         case .Vertical:
@@ -518,11 +520,13 @@ public class TZStackView: UIView {
                 constraints += equalAttributes(views: views, attribute: .Trailing)
             case .Center:
                 constraints += equalAttributes(views: views, attribute: .CenterX)
-            case .Leading, .Top:
+            case .Leading:
                 constraints += equalAttributes(views: views, attribute: .Leading)
-            case .Trailing, .Bottom:
+            case .Trailing:
                 constraints += equalAttributes(views: views, attribute: .Trailing)
             case .FirstBaseline:
+                constraints += []
+            case .LastBaseline:
                 constraints += []
             }
         }

--- a/TZStackView/TZStackView.swift
+++ b/TZStackView/TZStackView.swift
@@ -68,6 +68,15 @@ public class TZStackView: UIView {
         { self.arrangedSubviews = arrangedSubviews }()
     }
     
+    public required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)!
+      
+        ; // Ensure closure is not applied to previous line
+      
+        // Closure to invoke didSet()
+        { self.arrangedSubviews = self.subviews }()
+    }
+  
     deinit {
         // This removes `hidden` value KVO observers using didSet()
         { self.arrangedSubviews = [] }()
@@ -329,10 +338,6 @@ public class TZStackView: UIView {
         super.updateConstraints()
     }
 
-    required public init(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)!
-    }
-    
     private func addSpacerView() -> TZSpacerView {
         let spacerView = TZSpacerView()
         spacerView.translatesAutoresizingMaskIntoConstraints = false

--- a/TZStackView/TZStackView.swift
+++ b/TZStackView/TZStackView.swift
@@ -36,6 +36,8 @@ public class TZStackView: UIView {
     public var spacing: CGFloat = 0
     
     public var layoutMarginsRelativeArrangement = false
+  
+    public var baselineRelativeArrangement = false  // Currently ignored
 
     public private(set) var arrangedSubviews: [UIView] = [] {
         didSet {
@@ -71,15 +73,35 @@ public class TZStackView: UIView {
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)!
       
-        ; // Ensure closure is not applied to previous line
+      
+        self.axis = UILayoutConstraintAxis(rawValue: aDecoder.decodeIntegerForKey("UIStackViewAxis"))!
+        self.distribution = TZStackViewDistribution(rawValue: aDecoder.decodeIntegerForKey("UIStackViewDistribution"))!
+        self.alignment = TZStackViewAlignment(rawValue: aDecoder.decodeIntegerForKey("UIStackViewAlignment"))!
+        self.spacing = CGFloat(aDecoder.decodeDoubleForKey("UIStackViewSpacing"))
+        self.layoutMarginsRelativeArrangement = aDecoder.decodeBoolForKey("UIStackViewLayoutMarginsRelative")
+        self.baselineRelativeArrangement = aDecoder.decodeBoolForKey("UIStackViewBaselineRelative")
+   
+        ; // Ensure closure is separated properly
       
         // Closure to invoke didSet()
-        { self.arrangedSubviews = self.subviews }()
+        { self.arrangedSubviews = aDecoder.decodeObjectForKey("UIStackViewArrangedSubviews") as! [UIView] }()
     }
   
     deinit {
         // This removes `hidden` value KVO observers using didSet()
         { self.arrangedSubviews = [] }()
+    }
+  
+    public override func encodeWithCoder(aCoder: NSCoder) {
+        super.encodeWithCoder(aCoder)
+      
+        aCoder.encodeInteger(axis.rawValue, forKey: "UIStackViewAxis")
+        aCoder.encodeInteger(distribution.rawValue, forKey: "UIStackViewDistribution")
+        aCoder.encodeInteger(alignment.rawValue, forKey: "UIStackViewAlignment")
+        aCoder.encodeDouble(Double(spacing), forKey: "UIStackViewSpacing")
+        aCoder.encodeBool(layoutMarginsRelativeArrangement, forKey: "UIStackViewLayoutMarginsRelative")
+        aCoder.encodeBool(baselineRelativeArrangement, forKey: "UIStackViewBaselineRelative")
+        aCoder.encodeObject(arrangedSubviews, forKey: "UIStackViewArrangedSubviews")
     }
     
     private func registerHiddenListeners(previousArrangedSubviews: [UIView]) {

--- a/TZStackView/TZStackViewAlignment.swift
+++ b/TZStackView/TZStackViewAlignment.swift
@@ -9,11 +9,12 @@
 import Foundation
 
 @objc public enum TZStackViewAlignment: Int {
-    case Fill
-    case Center
-    case Leading
-    case Top
-    case Trailing
-    case Bottom
-    case FirstBaseline
+    case Fill             = 0
+    case Leading          = 1
+    case FirstBaseline    = 2
+    case Center           = 3
+    case Trailing         = 4
+    case LastBaseline     = 5
+    public static var Top : TZStackViewAlignment { return .Leading }
+    public static var Bottom : TZStackViewAlignment { return .Trailing }
 }


### PR DESCRIPTION
Generates a TZStackView subclass named UIStackView on platforms without a UIStackView.  Ensures TZStackView is used on iOS prior to 9 and the platform UIStackView on iOS 9+
