### PR TITLE
Fix for layout margin issue

### DIFF
--- a/TZStackView/TZStackView.swift
+++ b/TZStackView/TZStackView.swift
@@ -317,10 +317,10 @@ public class TZStackView: UIView {
 
             if layoutMarginsRelativeArrangement {
                 if spacerViews.count > 0 {
-                    stackViewConstraints.append(constraint(item: self, attribute: .BottomMargin, toItem: spacerViews[0]))
-                    stackViewConstraints.append(constraint(item: self, attribute: .LeftMargin, toItem: spacerViews[0]))
-                    stackViewConstraints.append(constraint(item: self, attribute: .RightMargin, toItem: spacerViews[0]))
-                    stackViewConstraints.append(constraint(item: self, attribute: .TopMargin, toItem: spacerViews[0]))
+                    stackViewConstraints.append(constraint(item: self, attribute: .BottomMargin, toItem: spacerViews[0], attribute: .Bottom))
+                    stackViewConstraints.append(constraint(item: self, attribute: .LeftMargin, toItem: spacerViews[0], attribute: .Left))
+                    stackViewConstraints.append(constraint(item: self, attribute: .RightMargin, toItem: spacerViews[0], attribute: .Right))
+                    stackViewConstraints.append(constraint(item: self, attribute: .TopMargin, toItem: spacerViews[0], attribute: .Top))
                 }
             }
             addConstraints(stackViewConstraints)


### PR DESCRIPTION
Fixed layout margin issue by creating the constraint between the edge of the TZSpacerView and the corresponding edgeMargin of the TZStackView. Which is consistent with the behavior of a UIStackView.

The issue with the previous implementation can be highlighted in the example below.

Assume
A is a StackView
B is a childView in A

if B has a default layoutMargin of UIEdgeInset(8,8,8,8) and A also has a default layoutMargin of UIEdgeInset(8,8,8,8).

expected result:
B.origin.x = 8

current/actual result:
A.origin.x = 0 (This is because the margin of B negates A's margin)

P.S. Thanks for the awesome work! Really saved me a ton of time using this in place of UIStackView for iOS 8 compatibility.
