### PR TITLE
Disable backgroundColor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
+.DS_Store
 
 # CocoaPods
 #

--- a/TZStackView/TZStackView.swift
+++ b/TZStackView/TZStackView.swift
@@ -56,9 +56,6 @@ public class TZStackView: UIView {
     private var registeredKvoSubviews = [UIView]()
     
     private var animatingToHiddenViews = [UIView]()
-    
-    // Disable setBackgroundColor to mimic an actual UIStackView which is a non-drawing view.
-    override public var backgroundColor: UIColor? { get { return nil } set { } }
 
     public init(arrangedSubviews: [UIView] = []) {
         super.init(frame: CGRectZero)
@@ -607,5 +604,10 @@ public class TZStackView: UIView {
             return true
         }
         return animatingToHiddenViews.indexOf(view) != nil
+    }
+    
+    // Disables setting the background color to mimic an actual UIStackView which is a non-drawing view.
+    override public class func layerClass() -> AnyClass {
+        return CATransformLayer.self
     }
 }

--- a/TZStackView/TZStackView.swift
+++ b/TZStackView/TZStackView.swift
@@ -57,15 +57,10 @@ public class TZStackView: UIView {
     
     private var animatingToHiddenViews = [UIView]()
     
-    private var _backgroundColor: UIColor? = nil
+    // Disable setBackgroundColor to mimic an actual UIStackView which is a non-drawing view.
     override public var backgroundColor: UIColor? {
-        get {
-            return self._backgroundColor
-        }
-        set {
-            // Disable setBackgroundColor to mimic a real UIStackView which is a non-drawing view.
-            self._backgroundColor = nil
-        }
+        get { return nil }
+        set { }
     }
 
     public init(arrangedSubviews: [UIView] = []) {

--- a/TZStackView/TZStackView.swift
+++ b/TZStackView/TZStackView.swift
@@ -56,6 +56,17 @@ public class TZStackView: UIView {
     private var registeredKvoSubviews = [UIView]()
     
     private var animatingToHiddenViews = [UIView]()
+    
+    private var _backgroundColor: UIColor? = nil
+    override public var backgroundColor: UIColor? {
+        get {
+            return self._backgroundColor
+        }
+        set {
+            // Disable setBackgroundColor to mimic a real UIStackView which is a non-drawing view.
+            self._backgroundColor = nil
+        }
+    }
 
     public init(arrangedSubviews: [UIView] = []) {
         super.init(frame: CGRectZero)

--- a/TZStackView/TZStackView.swift
+++ b/TZStackView/TZStackView.swift
@@ -58,10 +58,7 @@ public class TZStackView: UIView {
     private var animatingToHiddenViews = [UIView]()
     
     // Disable setBackgroundColor to mimic an actual UIStackView which is a non-drawing view.
-    override public var backgroundColor: UIColor? {
-        get { return nil }
-        set { }
-    }
+    override public var backgroundColor: UIColor? { get { return nil } set { } }
 
     public init(arrangedSubviews: [UIView] = []) {
         super.init(frame: CGRectZero)


### PR DESCRIPTION
Overrides the backgroundColor property inherited from UIView to be disabled.

This is in order to mimic an actual UIStackView, which is a non-drawing view, and protect users of TZStackView from becoming reliant on setting a TZStackView's background color. This should be one less surprise for users when they eventually migrate from TZStackView to UIStackView in the future.
