### PR TITLE
Make stack view IB designable

### DIFF
--- a/TZStackView.xcodeproj/project.pbxproj
+++ b/TZStackView.xcodeproj/project.pbxproj
@@ -13,13 +13,14 @@
 		5F50E9F2F7E5B2DA68C946E0 /* ExplicitIntrinsicContentSizeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F50E5EB8202F5247F8517F3 /* ExplicitIntrinsicContentSizeView.swift */; };
 		5F50EAD959E8ACC5929DBD75 /* NSLayoutConstraintExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB41AF691B294B8E003DB902 /* NSLayoutConstraintExtension.swift */; };
 		5F50EF474D670FC33E8E80EA /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5F50ED5A43FBFC32B9B9E1AA /* Images.xcassets */; };
+		7E214B741BF61501006448AC /* Storyboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7E214B731BF61501006448AC /* Storyboard.storyboard */; };
 		A45441C21B9B6D71002452BA /* TZStackView.h in Headers */ = {isa = PBXBuildFile; fileRef = A45441C11B9B6D71002452BA /* TZStackView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A45441C61B9B6D71002452BA /* TZStackView.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A45441BF1B9B6D71002452BA /* TZStackView.framework */; };
 		A45441C71B9B6D71002452BA /* TZStackView.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A45441BF1B9B6D71002452BA /* TZStackView.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		A45441D01B9B6D9C002452BA /* TZSpacerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45441CC1B9B6D9C002452BA /* TZSpacerView.swift */; settings = {ASSET_TAGS = (); }; };
-		A45441D11B9B6D9C002452BA /* TZStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45441CD1B9B6D9C002452BA /* TZStackView.swift */; settings = {ASSET_TAGS = (); }; };
-		A45441D21B9B6D9C002452BA /* TZStackViewAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45441CE1B9B6D9C002452BA /* TZStackViewAlignment.swift */; settings = {ASSET_TAGS = (); }; };
-		A45441D31B9B6D9C002452BA /* TZStackViewDistribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45441CF1B9B6D9C002452BA /* TZStackViewDistribution.swift */; settings = {ASSET_TAGS = (); }; };
+		A45441D01B9B6D9C002452BA /* TZSpacerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45441CC1B9B6D9C002452BA /* TZSpacerView.swift */; };
+		A45441D11B9B6D9C002452BA /* TZStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45441CD1B9B6D9C002452BA /* TZStackView.swift */; };
+		A45441D21B9B6D9C002452BA /* TZStackViewAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45441CE1B9B6D9C002452BA /* TZStackViewAlignment.swift */; };
+		A45441D31B9B6D9C002452BA /* TZStackViewDistribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = A45441CF1B9B6D9C002452BA /* TZStackViewDistribution.swift */; };
 		DB41AF6A1B294B8E003DB902 /* NSLayoutConstraintExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB41AF691B294B8E003DB902 /* NSLayoutConstraintExtension.swift */; };
 		DB5B70851B2A1963006043BD /* TestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5B70841B2A1963006043BD /* TestView.swift */; };
 		DB5B70871B2B8816006043BD /* TZStackViewTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5B70861B2B8816006043BD /* TZStackViewTestCase.swift */; };
@@ -67,6 +68,7 @@
 		5F50EDEB0947F99E67140FC6 /* TZStackViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TZStackViewTests.swift; sourceTree = "<group>"; };
 		5F50EF54F01A3A6938C6CEA1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5F50EFD0C46B7C7F989F10E1 /* TZStackViewTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TZStackViewTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		7E214B731BF61501006448AC /* Storyboard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Storyboard.storyboard; sourceTree = "<group>"; };
 		A45441BF1B9B6D71002452BA /* TZStackView.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TZStackView.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A45441C11B9B6D71002452BA /* TZStackView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TZStackView.h; sourceTree = "<group>"; };
 		A45441C31B9B6D71002452BA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -152,6 +154,7 @@
 				5F50ECF2FC09D64EB02F1309 /* ViewController.swift */,
 				5F50E5EB8202F5247F8517F3 /* ExplicitIntrinsicContentSizeView.swift */,
 				DB41AF691B294B8E003DB902 /* NSLayoutConstraintExtension.swift */,
+				7E214B731BF61501006448AC /* Storyboard.storyboard */,
 				DB614E5D1B292B630024E8AD /* LaunchScreen.xib */,
 				5F50ECF4A13687970498D9A7 /* Supporting Files */,
 				5F50ED5A43FBFC32B9B9E1AA /* Images.xcassets */,
@@ -298,6 +301,7 @@
 			files = (
 				DB614E5E1B292B630024E8AD /* LaunchScreen.xib in Resources */,
 				5F50EF474D670FC33E8E80EA /* Images.xcassets in Resources */,
+				7E214B741BF61501006448AC /* Storyboard.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TZStackView/TZStackView.h
+++ b/TZStackView/TZStackView.h
@@ -16,4 +16,5 @@ FOUNDATION_EXPORT const unsigned char TZStackViewVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <TZStackView/PublicHeader.h>
 
-
+#define TZStackViewAlignmentTop TZStackViewAlignmentLeading
+#define TZStackViewAlignmentBottom TZStackViewAlignmentTrailing

--- a/TZStackView/TZStackView.swift
+++ b/TZStackView/TZStackView.swift
@@ -476,9 +476,9 @@ public class TZStackView: UIView {
                 constraints += equalAttributes(views: views, attribute: .Top)
             case .Center:
                 constraints += equalAttributes(views: views, attribute: .CenterY)
-            case .Leading, .Top:
+            case .Leading:
                 constraints += equalAttributes(views: views, attribute: .Top)
-            case .Trailing, .Bottom:
+            case .Trailing:
                 constraints += equalAttributes(views: views, attribute: .Bottom)
             case .FirstBaseline:
                 constraints += equalAttributes(views: views, attribute: .FirstBaseline)
@@ -491,9 +491,9 @@ public class TZStackView: UIView {
                 constraints += equalAttributes(views: views, attribute: .Trailing)
             case .Center:
                 constraints += equalAttributes(views: views, attribute: .CenterX)
-            case .Leading, .Top:
+            case .Leading:
                 constraints += equalAttributes(views: views, attribute: .Leading)
-            case .Trailing, .Bottom:
+            case .Trailing:
                 constraints += equalAttributes(views: views, attribute: .Trailing)
             case .FirstBaseline:
                 constraints += []

--- a/TZStackView/TZStackViewAlignment.swift
+++ b/TZStackView/TZStackViewAlignment.swift
@@ -8,12 +8,33 @@
 
 import Foundation
 
-@objc public enum TZStackViewAlignment: Int {
-    case Fill
-    case Center
-    case Leading
-    case Top
-    case Trailing
-    case Bottom
-    case FirstBaseline
+/* Alignment—the layout transverse to the stacking axis.
+*/
+@objc public enum TZStackViewAlignment : Int {
+    
+    /* Align the leading and trailing edges of vertically stacked items
+    or the top and bottom edges of horizontally stacked items tightly to the container.
+    */
+    case Fill = 0
+    
+    /* Align the leading edges of vertically stacked items
+    or the top edges of horizontally stacked items tightly to the relevant edge
+    of the container
+    */
+    case Leading = 1
+    public static let Top: TZStackViewAlignment = .Leading
+    case FirstBaseline = 2 // Valid for horizontal axis only
+    
+    /* Center the items in a vertical stack horizontally
+    or the items in a horizontal stack vertically
+    */
+    case Center = 3
+    
+    /* Align the trailing edges of vertically stacked items
+    or the bottom edges of horizontally stacked items tightly to the relevant
+    edge of the container
+    */
+    case Trailing = 4
+    public static let Bottom: TZStackViewAlignment = .Trailing
+//    case LastBaseline = 5 // Valid for horizontal axis only
 }

--- a/TZStackView/TZStackViewDistribution.swift
+++ b/TZStackView/TZStackViewDistribution.swift
@@ -7,10 +7,45 @@
 //
 import Foundation
 
-@objc public enum TZStackViewDistribution: Int {
-    case Fill
-    case FillEqually
-    case FillProportionally
-    case EqualSpacing
-    case EqualCentering
+/* Distribution—the layout along the stacking axis.
+
+All UIStackViewDistribution enum values fit first and last arranged subviews tightly to the container,
+and except for UIStackViewDistributionFillEqually, fit all items to intrinsicContentSize when possible.
+*/
+@objc public enum TZStackViewDistribution : Int {
+    
+    /* When items do not fit (overflow) or fill (underflow) the space available
+    adjustments occur according to compressionResistance or hugging
+    priorities of items, or when that is ambiguous, according to arrangement
+    order.
+    */
+    case Fill = 0
+    
+    /* Items are all the same size.
+    When space allows, this will be the size of the item with the largest
+    intrinsicContentSize (along the axis of the stack).
+    Overflow or underflow adjustments are distributed equally among the items.
+    */
+    case FillEqually = 1
+    
+    /* Overflow or underflow adjustments are distributed among the items proportional
+    to their intrinsicContentSizes.
+    */
+    case FillProportionally = 2
+    
+    /* Additional underflow spacing is divided equally in the spaces between the items.
+    Overflow squeezing is controlled by compressionResistance priorities followed by
+    arrangement order.
+    */
+    case EqualSpacing = 3
+    
+    /* Equal center-to-center spacing of the items is maintained as much
+    as possible while still maintaining a minimum edge-to-edge spacing within the
+    allowed area.
+    Additional underflow spacing is divided equally in the spacing. Overflow
+    squeezing is distributed first according to compressionResistance priorities
+    of items, then according to subview order while maintaining the configured
+    (edge-to-edge) spacing as a minimum.
+    */
+    case EqualCentering = 4
 }

--- a/TZStackViewDemo/Storyboard.storyboard
+++ b/TZStackViewDemo/Storyboard.storyboard
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="7Pk-gO-Sfp">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="mKt-1r-UG0">
+            <objects>
+                <viewController id="7Pk-gO-Sfp" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="26K-5f-ULN"/>
+                        <viewControllerLayoutGuide type="bottom" id="5Bf-KN-2hd"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="v4o-ZE-3zH">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6s3-bg-nnE" customClass="TZStackView" customModule="TZStackView">
+                                <rect key="frame" x="20" y="96" width="260" height="40"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3mZ-F9-6Yn">
+                                        <rect key="frame" x="0.0" y="0.0" width="40" height="40"/>
+                                        <color key="backgroundColor" red="1" green="0.39365052516480326" blue="0.00066504108442033694" alpha="1" colorSpace="calibratedRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="40" id="gSk-GL-9wB"/>
+                                            <constraint firstAttribute="height" constant="40" id="ihU-hB-oMh"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qpO-Hi-qhg">
+                                        <rect key="frame" x="50" y="0.0" width="120" height="40"/>
+                                        <color key="backgroundColor" red="0.91325297599999999" green="1" blue="0.32812390159999999" alpha="1" colorSpace="calibratedRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="120" id="ctS-ke-ygE"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vKs-Mr-kZj">
+                                        <rect key="frame" x="180" y="0.0" width="80" height="40"/>
+                                        <color key="backgroundColor" red="1" green="0.0" blue="0.11998722730612776" alpha="1" colorSpace="calibratedRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="80" id="DWv-8d-siY"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="axisValue">
+                                        <integer key="value" value="0"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="alignmentValue">
+                                        <integer key="value" value="0"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="distributionValue">
+                                        <integer key="value" value="0"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="spacing">
+                                        <real key="value" value="10"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FZG-Ni-QDX" customClass="TZStackView" customModule="TZStackView">
+                                <rect key="frame" x="20" y="156" width="560" height="120"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CI1-Gc-kfJ">
+                                        <rect key="frame" x="0.0" y="40" width="40" height="40"/>
+                                        <color key="backgroundColor" red="1" green="0.39365052519999999" blue="0.00066504108440000001" alpha="1" colorSpace="calibratedRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="40" id="dEm-Cm-VMS"/>
+                                            <constraint firstAttribute="height" constant="40" id="i0z-93-hdh"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="f9j-tg-iYC">
+                                        <rect key="frame" x="200" y="0.0" width="120" height="120"/>
+                                        <color key="backgroundColor" red="0.91325297601285937" green="1" blue="0.32812390158040894" alpha="1" colorSpace="calibratedRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="120" id="JLc-Yc-j39"/>
+                                            <constraint firstAttribute="height" constant="120" id="uia-9L-jaT"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dE2-5f-0am">
+                                        <rect key="frame" x="480" y="20" width="80" height="80"/>
+                                        <color key="backgroundColor" red="1" green="0.0" blue="0.1199872273" alpha="1" colorSpace="calibratedRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="80" id="5JT-Rc-NRL"/>
+                                            <constraint firstAttribute="width" constant="80" id="LiZ-h4-MQ2"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="axisValue">
+                                        <integer key="value" value="0"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="alignmentValue">
+                                        <integer key="value" value="3"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="distributionValue">
+                                        <integer key="value" value="3"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="spacing">
+                                        <real key="value" value="0.0"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Checkout the “Storyboard.storyboard” file to see how these two stack views are set up in Interface Builder without code." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cjR-kc-qyi">
+                                <rect key="frame" x="20" y="40" width="560" height="36"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="cjR-kc-qyi" firstAttribute="leading" secondItem="v4o-ZE-3zH" secondAttribute="leading" constant="20" id="3Wb-Os-UTe"/>
+                            <constraint firstItem="FZG-Ni-QDX" firstAttribute="leading" secondItem="v4o-ZE-3zH" secondAttribute="leading" constant="20" id="P1i-Po-R0X"/>
+                            <constraint firstItem="6s3-bg-nnE" firstAttribute="top" secondItem="cjR-kc-qyi" secondAttribute="bottom" constant="20" id="Phy-ri-Hvg"/>
+                            <constraint firstAttribute="trailing" secondItem="FZG-Ni-QDX" secondAttribute="trailing" constant="20" id="VSD-uS-puT"/>
+                            <constraint firstItem="cjR-kc-qyi" firstAttribute="top" secondItem="26K-5f-ULN" secondAttribute="bottom" constant="20" id="Y9Z-by-W9a"/>
+                            <constraint firstItem="6s3-bg-nnE" firstAttribute="leading" secondItem="v4o-ZE-3zH" secondAttribute="leading" constant="20" id="iPH-38-4B2"/>
+                            <constraint firstAttribute="trailing" secondItem="cjR-kc-qyi" secondAttribute="trailing" constant="20" id="lap-bl-kaF"/>
+                            <constraint firstItem="FZG-Ni-QDX" firstAttribute="top" secondItem="6s3-bg-nnE" secondAttribute="bottom" constant="20" id="ya5-LQ-jZc"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="hJ3-hI-PWJ" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="472" y="306"/>
+        </scene>
+    </scenes>
+</document>

--- a/TZStackViewDemo/ViewController.swift
+++ b/TZStackViewDemo/ViewController.swift
@@ -39,6 +39,14 @@ class ViewController: UIViewController {
         tzStackView.spacing = 15
         view.addSubview(tzStackView)
 
+        let toIBButton = UIButton(type: .System)
+        toIBButton.translatesAutoresizingMaskIntoConstraints = false
+        toIBButton.setTitle("Storyboard Views", forState: .Normal)
+        toIBButton.addTarget(self, action: "toIB", forControlEvents: .TouchUpInside)
+        toIBButton.setContentCompressionResistancePriority(1000, forAxis: .Vertical)
+        toIBButton.setContentHuggingPriority(1000, forAxis: .Vertical)
+        view.addSubview(toIBButton)
+
         instructionLabel.translatesAutoresizingMaskIntoConstraints = false
         instructionLabel.font = UIFont.systemFontOfSize(15)
         instructionLabel.text = "Tap any of the boxes to set hidden=true"
@@ -84,6 +92,7 @@ class ViewController: UIViewController {
         view.addSubview(controlsLayoutContainer)
 
         let views: [String:AnyObject] = [
+                "toIBButton": toIBButton,
                 "instructionLabel": instructionLabel,
                 "resetButton": resetButton,
                 "tzStackView": tzStackView,
@@ -95,6 +104,8 @@ class ViewController: UIViewController {
                 "topspacing": 25
         ]
 
+        view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:[toIBButton]-gap-|",
+            options: NSLayoutFormatOptions(rawValue: 0), metrics: metrics, views: views))
         view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|-gap-[instructionLabel]-[resetButton]-gap-|",
                 options: NSLayoutFormatOptions(rawValue: 0), metrics: metrics, views: views))
         view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|[tzStackView]|",
@@ -102,7 +113,7 @@ class ViewController: UIViewController {
         view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|[controlsLayoutContainer]|",
                 options: NSLayoutFormatOptions(rawValue: 0), metrics: metrics, views: views))
 
-        view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|-topspacing-[instructionLabel]-gap-[controlsLayoutContainer]-gap-[tzStackView]|",
+        view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|-topspacing-[toIBButton]-gap-[instructionLabel]-gap-[controlsLayoutContainer]-gap-[tzStackView]|",
                 options: NSLayoutFormatOptions(rawValue: 0), metrics: metrics, views: views))
         view.addConstraint(NSLayoutConstraint(item: instructionLabel, attribute: .CenterY, relatedBy: .Equal, toItem: resetButton, attribute: .CenterY, multiplier: 1, constant: 0))
     }
@@ -141,6 +152,22 @@ class ViewController: UIViewController {
             }
         }, completion: nil)
 
+    }
+    
+    func toIB() {
+        
+        let storyboard = UIStoryboard(name: "Storyboard", bundle: nil)
+        let viewController = storyboard.instantiateInitialViewController()!
+        viewController.navigationItem.rightBarButtonItem = UIBarButtonItem.init(barButtonSystemItem: .Cancel, target: self, action: "backFromIB")
+        
+        let navController = UINavigationController(rootViewController: viewController)
+        
+        presentViewController(navController, animated: true, completion: nil)
+        
+    }
+    
+    func backFromIB() {
+        dismissViewControllerAnimated(true, completion:nil)
     }
 
     //MARK: - Segmented Control Actions

--- a/TZStackViewDemo/ViewController.swift
+++ b/TZStackViewDemo/ViewController.swift
@@ -45,6 +45,7 @@ class ViewController: UIViewController {
         instructionLabel.textColor = UIColor.whiteColor()
         instructionLabel.numberOfLines = 0
         instructionLabel.setContentCompressionResistancePriority(900, forAxis: .Horizontal)
+        instructionLabel.setContentCompressionResistancePriority(1000, forAxis: .Vertical)
         instructionLabel.setContentHuggingPriority(1000, forAxis: .Vertical)
         view.addSubview(instructionLabel)
 
@@ -53,31 +54,33 @@ class ViewController: UIViewController {
         resetButton.addTarget(self, action: "reset", forControlEvents: .TouchUpInside)
         resetButton.setContentCompressionResistancePriority(1000, forAxis: .Horizontal)
         resetButton.setContentHuggingPriority(1000, forAxis: .Horizontal)
-        resetButton.setContentHuggingPriority(1000, forAxis: .Vertical)
         view.addSubview(resetButton)
 
         axisSegmentedControl = UISegmentedControl(items: ["Vertical", "Horizontal"])
         axisSegmentedControl.selectedSegmentIndex = 0
         axisSegmentedControl.addTarget(self, action: "axisChanged:", forControlEvents: .ValueChanged)
-        axisSegmentedControl.setContentCompressionResistancePriority(900, forAxis: .Horizontal)
+        axisSegmentedControl.setContentCompressionResistancePriority(1000, forAxis: .Vertical)
+        axisSegmentedControl.setContentHuggingPriority(1000, forAxis: .Vertical)
         axisSegmentedControl.tintColor = UIColor.lightGrayColor()
 
         alignmentSegmentedControl = UISegmentedControl(items: ["Fill", "Center", "Leading", "Top", "Trailing", "Bottom", "FirstBaseline"])
         alignmentSegmentedControl.selectedSegmentIndex = 0
         alignmentSegmentedControl.addTarget(self, action: "alignmentChanged:", forControlEvents: .ValueChanged)
-        alignmentSegmentedControl.setContentCompressionResistancePriority(1000, forAxis: .Horizontal)
+        alignmentSegmentedControl.setContentCompressionResistancePriority(1000, forAxis: .Vertical)
+        alignmentSegmentedControl.setContentHuggingPriority(1000, forAxis: .Vertical)
         alignmentSegmentedControl.tintColor = UIColor.lightGrayColor()
 
         distributionSegmentedControl = UISegmentedControl(items: ["Fill", "FillEqually", "FillProportionally", "EqualSpacing", "EqualCentering"])
         distributionSegmentedControl.selectedSegmentIndex = 0
         distributionSegmentedControl.addTarget(self, action: "distributionChanged:", forControlEvents: .ValueChanged)
+        distributionSegmentedControl.setContentCompressionResistancePriority(1000, forAxis: .Vertical)
+        distributionSegmentedControl.setContentHuggingPriority(1000, forAxis: .Vertical)
         distributionSegmentedControl.tintColor = UIColor.lightGrayColor()
 
         let controlsLayoutContainer = TZStackView(arrangedSubviews: [axisSegmentedControl, alignmentSegmentedControl, distributionSegmentedControl])
         controlsLayoutContainer.axis = .Vertical
         controlsLayoutContainer.translatesAutoresizingMaskIntoConstraints = false
         controlsLayoutContainer.spacing = 5
-        controlsLayoutContainer.setContentHuggingPriority(1000, forAxis: .Vertical)
         view.addSubview(controlsLayoutContainer)
 
         let views: [String:AnyObject] = [
@@ -101,8 +104,7 @@ class ViewController: UIViewController {
 
         view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|-topspacing-[instructionLabel]-gap-[controlsLayoutContainer]-gap-[tzStackView]|",
                 options: NSLayoutFormatOptions(rawValue: 0), metrics: metrics, views: views))
-        view.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|-topspacing-[resetButton]-gap-[controlsLayoutContainer]",
-                options: NSLayoutFormatOptions(rawValue: 0), metrics: metrics, views: views))
+        view.addConstraint(NSLayoutConstraint(item: instructionLabel, attribute: .CenterY, relatedBy: .Equal, toItem: resetButton, attribute: .CenterY, multiplier: 1, constant: 0))
     }
 
     private func createViews() -> [UIView] {
@@ -111,6 +113,16 @@ class ViewController: UIViewController {
         let blueView = ExplicitIntrinsicContentSizeView(intrinsicContentSize: CGSize(width: 60, height: 60), name: "Blue")
         let purpleView = ExplicitIntrinsicContentSizeView(intrinsicContentSize: CGSize(width: 80, height: 80), name: "Purple")
         let yellowView = ExplicitIntrinsicContentSizeView(intrinsicContentSize: CGSize(width: 100, height: 100), name: "Yellow")
+        
+        let views = [redView, greenView, blueView, purpleView, yellowView]
+        
+        for (i, view) in views.enumerate() {
+            let j = UILayoutPriority(i)
+            view.setContentCompressionResistancePriority(751 + j, forAxis: .Horizontal)
+            view.setContentCompressionResistancePriority(751 + j, forAxis: .Vertical)
+            view.setContentHuggingPriority(251 + j, forAxis: .Horizontal)
+            view.setContentHuggingPriority(251 + j, forAxis: .Vertical)
+        }
 
         redView.backgroundColor = UIColor.redColor().colorWithAlphaComponent(0.75)
         greenView.backgroundColor = UIColor.greenColor().colorWithAlphaComponent(0.75)


### PR DESCRIPTION
You can design stack view and see layout result at _design time_ in Interface Builder.

After you setup your stack view and its subviews in Interface Builder, click one subview of the stack view, and press ⌥⌘= , then the subview will be placed to its right position automatically.
