### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ So this implementation does **not** support Storyboard. It is meant for iOS deve
 ## Setup
 You basically have two options to include the `TZStackView` in your *Xcode* project:
 
-### Use [Cocoapods](http://cocoapods.org/)
+### Use [CocoaPods](http://cocoapods.org/)
 Example `Podfile`:
 ```ruby
 source 'https://github.com/CocoaPods/Specs.git'
@@ -23,7 +23,7 @@ use_frameworks!
 
 pod "TZStackView", "1.1.2"
 ```
-Unfortunately, using Cocoapods with a Swift pod requires iOS 8.
+Unfortunately, using CocoaPods with a Swift pod requires iOS 8.
 
 ### Use [Carthage](https://github.com/Carthage/Carthage)
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
