### PR TITLE
Fixed divide by 0 «NaN» crash

### DIFF
--- a/TZStackView/TZStackView.swift
+++ b/TZStackView/TZStackView.swift
@@ -402,6 +402,11 @@ public class TZStackView: UIView {
         }
         totalSize += (CGFloat(totalCount - 1) * spacing)
         
+        // Prevent ÷0 crash when all arranged subviews have their total size equal to 0
+        if totalSize == 0 {
+            totalSize = 1
+        }
+        
         var priority: Float = 1000
         let countDownPriority = (views.filter({!self.isHidden($0)}).count > 1)
         for arrangedSubview in views {


### PR DESCRIPTION
If the distribution is set to FillProportionally and all arranged subviews have their total size equal 0 (typical example is there's a single arrangedSubview which intrinsicContentSize is CGSizeZero), we have a crash later when creating the constraints

`let multiplier = arrangedSubview.intrinsicContentSize().width / totalSize
                constraints.append(constraint(item: arrangedSubview, attribute: .Width, toItem: self, multiplier: multiplier, priority: priority))`

multiplier is NaN and we have a crash creating the constraint.
